### PR TITLE
BUG: MapBox location attributes retrieve was wrong in alert detail

### DIFF
--- a/src/app/services/map/utils/reverseLookup.ts
+++ b/src/app/services/map/utils/reverseLookup.ts
@@ -42,6 +42,6 @@ export function reverseLookup(
 
   return axios.get(url, { cancelToken })
     .then((data) => {
-      return _.get<string>(data, 'features[0].place_name');
+      return _.get<string>(data.data, 'features[0].place_name');
     });
 }


### PR DESCRIPTION
In Alert detail there's a bug (or maybe mapbox has changed something in API): place_name is under data.location[0].place_name.